### PR TITLE
Add `strict` flag to constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,14 @@ following fields:
   Set it to false to have '-h' **not** get parsed as an option in the above
   example.
 
+- `strict` (Boolean).  Option.  Default is true.  If true, this causes
+  unknown arguments to throw an error.  I.e.:
+
+        node ./tool.js -v arg1 --afe8asefksjefhas
+
+  Set it to false to treat the unknown option as a positional
+  argument.
+
 
 # Option specs
 

--- a/lib/dashdash.js
+++ b/lib/dashdash.js
@@ -191,6 +191,8 @@ var types = {
  * @param config {Object} The parser configuration
  *      - options {Array} Array of option specs. See the README for how to
  *        specify each option spec.
+ *      - strict {Boolean} Default true. Whether to throw on unknown options.
+ *        If false, then unknown args are included in the _args array.
  *      - interspersed {Boolean} Default true. Whether to allow interspersed
  *        arguments (non-options) and options. E.g.:
  *              node tool.js arg1 arg2 -v
@@ -208,6 +210,10 @@ function Parser(config) {
     // Allow interspersed arguments (true by default).
     this.interspersed = (config.interspersed !== undefined
         ? config.interspersed : true);
+
+    // Don't allow unknown flags (true by default).
+    this.strict = (config.strict !== undefined
+        ? config.strict : true);
 
     this.options = config.options.map(function (o) { return shallowCopy(o); });
     this.optionFromName = {};
@@ -309,7 +315,7 @@ Parser.prototype.parse = function parse(inputs) {
     // Parse args.
     var _args = [];
     var i = 0;
-    while (i < args.length) {
+    outer: while (i < args.length) {
         var arg = args[i];
 
         // End of options marker.
@@ -328,43 +334,66 @@ Parser.prototype.parse = function parse(inputs) {
             }
             var option = this.optionFromName[name];
             if (!option) {
-                throw new Error(format('unknown option: "--%s"', name));
-            }
-            var takesArg = this.optionTakesArg(option);
-            if (val !== null && !takesArg) {
-                throw new Error(format('argument given to "--%s" option '
-                    + 'that does not take one: "%s"', name, arg));
-            }
-            if (!takesArg) {
-                addOpt(option, '--'+name, option.key, true, 'argv');
-            } else if (val !== null) {
-                addOpt(option, '--'+name, option.key, val, 'argv');
-            } else if (i + 1 >= args.length) {
-                throw new Error(format('do not have enough args for "--%s" '
-                    + 'option', name));
+                if (this.strict)
+                    throw new Error(format('unknown option: "--%s"', name));
+                else if (this.interspersed)
+                    _args.push(arg);
+                else
+                    break outer;
             } else {
-                addOpt(option, '--'+name, option.key, args[i + 1], 'argv');
-                i++;
+                var takesArg = this.optionTakesArg(option);
+                if (val !== null && !takesArg) {
+                    throw new Error(format('argument given to "--%s" option '
+                        + 'that does not take one: "%s"', name, arg));
+                }
+                if (!takesArg) {
+                    addOpt(option, '--'+name, option.key, true, 'argv');
+                } else if (val !== null) {
+                    addOpt(option, '--'+name, option.key, val, 'argv');
+                } else if (i + 1 >= args.length) {
+                    throw new Error(format('do not have enough args for "--%s" '
+                        + 'option', name));
+                } else {
+                    addOpt(option, '--'+name, option.key, args[i + 1], 'argv');
+                    i++;
+                }
             }
 
         // Short option
         } else if (arg[0] === '-' && arg.length > 1) {
             var j = 1;
+            var allFound = true;
             while (j < arg.length) {
                 var name = arg[j];
-                var val = arg.slice(j + 1);  // option val if it takes an arg
                 // debug('name: %s (val: %s)', name, val)
                 var option = this.optionFromName[name];
                 if (!option) {
-                    if (arg.length > 2) {
+                    allFound = false;
+                    if (!this.strict) {
+                        if (this.interspersed) {
+                            _args.push(arg);
+                            break;
+                        } else
+                            break outer;
+                    } else if (arg.length > 2) {
                         throw new Error(format(
                             'unknown option: "-%s" in "%s" group',
                             name, arg));
                     } else {
                         throw new Error(format('unknown option: "-%s"', name));
                     }
+                } else if (this.optionTakesArg(option)) {
+                  break;
                 }
+                j++;
+            }
+
+            j = 1;
+            while (allFound && j < arg.length) {
+                var name = arg[j];
+                var val = arg.slice(j + 1);  // option val if it takes an arg
                 var takesArg = this.optionTakesArg(option);
+                var option = this.optionFromName[name];
                 if (!takesArg) {
                     addOpt(option, '-'+name, option.key, true, 'argv');
                 } else if (val) {
@@ -388,7 +417,7 @@ Parser.prototype.parse = function parse(inputs) {
 
         // An arg and interspersed args are not allowed, so done options.
         } else {
-            break;
+            break outer;
         }
         i++;
     }

--- a/test/basics.test.js
+++ b/test/basics.test.js
@@ -705,7 +705,19 @@ var cases = [
         env: {FOO_VERBOSE: '0'},
         expect: { verbose: true, _args: [] }
     },
+
+    // unstrict
+    {
+        options: [ {name: 'help', type: 'bool'} ],
+        argv: 'node tool.js a --help -b --cheese',
+        strict: false,
+        expect: {
+            help: true,
+            _args: ['a', '-b', '--cheese']
+        }
+    },
 ];
+
 cases.forEach(function (c, num) {
     var expect = c.expect;
     delete c.expect;


### PR DESCRIPTION
Set to false to allow parsing argv arrays that may contain
unknown arguments.  While you typically would not want to
set this to false, it does become useful if you want to pull
SOME data out of a command line, but perhaps not all of it.
