### PR TITLE
Add helpWrap formatting parameter

### DIFF
--- a/lib/dashdash.js
+++ b/lib/dashdash.js
@@ -540,6 +540,7 @@ Parser.prototype.parse = function parse(inputs) {
  *      - minHelpCol {Number} Default 20.
  *      - maxHelpCol {Number} Default 40.
  *      - includeEnv {Boolean} Default false.
+ *      - wrapHelp {Boolean} Default true. Wrap help text to maxCol.
  * @returns {String}
  */
 Parser.prototype.help = function help(config) {
@@ -562,6 +563,7 @@ Parser.prototype.help = function help(config) {
     var maxCol = config.maxCol || 80;
     var minHelpCol = config.minHelpCol || 20;
     var maxHelpCol = config.maxHelpCol || 40;
+    var helpWrap = (config.helpWrap === undefined) ? true : config.helpWrap;
 
     var lines = [];
     var maxWidth = 0;
@@ -626,15 +628,10 @@ Parser.prototype.help = function help(config) {
         } else {
             line += '\n' + space(helpCol);
         }
-        var help = (o.help || '').trim();
+
+        var helpEnv = '';
         if (o.env && o.env.length && config.includeEnv) {
-            if (help.length && !~'.!?'.indexOf(help.slice(-1))) {
-                help += '.';
-            }
-            if (help.length) {
-                help += ' ';
-            }
-            help += 'Environment: ';
+            helpEnv += 'Environment: ';
             var type = optionTypes[o.type];
             var arg = o.helpArg || type.helpArg || 'ARG';
             var envs = (Array.isArray(o.env) ? o.env : [o.env]).map(
@@ -646,10 +643,37 @@ Parser.prototype.help = function help(config) {
                     }
                 }
             );
-            help += envs.join(', ');
+            helpEnv += envs.join(', ');
         }
-        line += textwrap(help, maxCol - helpCol).join(
-            '\n' + space(helpCol));
+        var help = (o.help || '').trim();
+        if ((o.helpWrap !== false && helpWrap !== false) ||
+            (o.helpWrap === true)) {
+            // Wrap help description normally
+            if (help.length && !~'.!?'.indexOf(help.slice(-1))) {
+                help += '.';
+            }
+            if (help.length) {
+                help += ' ';
+            }
+            help += helpEnv;
+            line += textwrap(help, maxCol - helpCol).join(
+                '\n' + space(helpCol));
+        } else {
+            // Do not wrap help line(s), but indent newlines appropriately
+            var helpLines = help.split('\n');
+            if (helpEnv !== '') {
+                helpLines.push(helpEnv);
+            }
+            line += helpLines.map(function (hline, idx) {
+                if (idx === 0) {
+                    // the first line is already indented for us
+                    return hline;
+                } else {
+                    return space(helpCol) + hline;
+                }
+            }).join('\n');
+        }
+
         lines[i] = line;
     });
 


### PR DESCRIPTION
Disabling helpWrap bypasses the filters imposed by textwrap allowing consumers to craft custom formatted help descriptions.
