### PR TITLE
Add ability to negate bool options using a specified prefix

### DIFF
--- a/lib/dashdash.js
+++ b/lib/dashdash.js
@@ -172,7 +172,8 @@ function parseDate(option, optstr, arg) {
 var optionTypes = {
     bool: {
         takesArg: false,
-        parseArg: parseBool
+        parseArg: parseBool,
+        allowBoolNegationPrefix: true
     },
     string: {
         takesArg: true,
@@ -202,7 +203,8 @@ var optionTypes = {
     arrayOfBool: {
         takesArg: false,
         array: true,
-        parseArg: parseBool
+        parseArg: parseBool,
+        allowBoolNegationPrefix: true
     },
     arrayOfString: {
         takesArg: true,
@@ -260,6 +262,7 @@ function Parser(config) {
     assert.object(config, 'config');
     assert.arrayOfObject(config.options, 'config.options');
     assert.optionalBool(config.interspersed, 'config.interspersed');
+    assert.optionalString(config.boolNegationPrefix, 'config.boolNegationPrefix');
     var self = this;
 
     // Allow interspersed arguments (true by default).
@@ -299,6 +302,12 @@ function Parser(config) {
         assert.optionalBool(o.helpWrap,
             format('config.options.%d.helpWrap', i));
         assert.optionalBool(o.hidden, format('config.options.%d.hidden', i));
+        assert.optionalString(o.boolNegationPrefix, format('config.options.%d.boolNegationPrefix', i));
+
+        // Use the global `boolNegationPrefix` if not overriden by the option
+        if (optionTypes[o.type].allowBoolNegationPrefix) {
+            o.boolNegationPrefix = o.boolNegationPrefix || config.boolNegationPrefix;
+        }
 
         if (o.name) {
             o.names = [o.name];
@@ -314,6 +323,11 @@ function Parser(config) {
                     n, self.optionFromName[n], o));
             }
             self.optionFromName[n] = o;
+
+            // Add the negated option name
+            if (o.boolNegationPrefix) {
+                self.optionFromName[o.boolNegationPrefix + n] = o;
+            }
         });
         env.forEach(function (n) {
             if (self.optionFromEnv[n]) {
@@ -415,7 +429,12 @@ Parser.prototype.parse = function parse(inputs) {
                         + 'that does not take one: "%s"', name, arg));
                 }
                 if (!takesArg) {
-                    addOpt(option, '--'+name, option.key, true, 'argv');
+                    // Use the specified default, or true if there is no default
+                    var bool = (option.default === undefined) ? true : option.default;
+                    if (option.boolNegationPrefix && name.indexOf(option.boolNegationPrefix) === 0) {
+                        bool = !bool;
+                    }
+                    addOpt(option, '--'+name, option.key, bool, 'argv');
                 } else if (val !== null) {
                     addOpt(option, '--'+name, option.key, val, 'argv');
                 } else if (i + 1 >= args.length) {

--- a/lib/dashdash.js
+++ b/lib/dashdash.js
@@ -633,7 +633,11 @@ Parser.prototype.help = function help(config) {
                 if (type.takesArg)
                     line += ' ' + arg;
             } else {
-                line += '--' + name
+                line += '--';
+                if (o.boolNegationPrefix) {
+                    line += '['+ o.boolNegationPrefix +']';
+                }
+                line += name;
                 if (type.takesArg)
                     line += '=' + arg;
             }

--- a/test/basics.test.js
+++ b/test/basics.test.js
@@ -504,6 +504,14 @@ var cases = [
     },
     {
         options: [
+            {names: ['help', 'h'], type: 'bool', help: 'Show help and exit.'}
+        ],
+        boolNegationPrefix: 'no-',
+        argv: 'node tool.js --help',
+        expectHelp: /-h, --\[no-\]help\s+Show help and exit./
+    },
+    {
+        options: [
             { names: ['help', 'h'], type: 'bool' },
             { group: 'first group' },
             { names: [ 'first-one', 'f' ], type: 'bool' },

--- a/test/basics.test.js
+++ b/test/basics.test.js
@@ -242,6 +242,60 @@ var cases = [
             _args: []
         }
     },
+    {
+        options: [ {name: 'enable', type: 'bool'} ],
+        argv: 'node tool.js --enable',
+        expect: {
+            enable: true,
+            _args: []
+        }
+    },
+    {
+        options: [ {name: 'enable', type: 'bool', default: true} ],
+        boolNegationPrefix: 'no-',
+        argv: 'node tool.js --no-enable',
+        expect: {
+            enable: false,
+            _args: []
+        }
+    },
+    {
+        options: [ {name: 'toast', type: 'bool', default: false} ],
+        boolNegationPrefix: 'enable-',
+        argv: 'node tool.js --enable-toast',
+        expect: {
+            toast: true,
+            _args: []
+        }
+    },
+    {
+        options: [ {name: 'enable', type: 'arrayOfBool', default: true} ],
+        boolNegationPrefix: 'no-',
+        argv: 'node tool.js --no-enable --no-enable',
+        expect: {
+            enable: [ false, false ],
+            _args: []
+        }
+    },
+    {
+        options: [
+            {name: 'toast', type: 'bool', default: true, boolNegationPrefix: 'disable-'},
+            {name: 'enable', type: 'bool', default: true}
+        ],
+        boolNegationPrefix: 'no-',
+        argv: 'node tool.js --disable-toast --no-enable',
+        expect: {
+            toast: false,
+            enable: false,
+            _args: []
+        }
+    },
+    {
+        options: [ {name: 'file', type: 'string'} ],
+        boolNegationPrefix: 'off-',
+        argv: 'node tool.js --no-file',
+        expect: /unknown option: "--no-file"/
+    },
 
     // short opts
     {


### PR DESCRIPTION
- Adds a new `boolNegationPrefix` option when configuring a new parser.
- Each option can override the `boolNegationPrefix` as needed.
