### PR TITLE
Default maxCol to the console width - 1

### DIFF
--- a/lib/dashdash.js
+++ b/lib/dashdash.js
@@ -555,7 +555,8 @@ Parser.prototype.parse = function parse(inputs) {
  *      - nameSort {String} Default is 'length'. By default the names are
  *        sorted to put the short opts first (i.e. '-h, --help' preferred
  *        to '--help, -h'). Set to 'none' to not do this sorting.
- *      - maxCol {Number} Default 80. Note that long tokens in a help string
+ *      - maxCol {Number} Default is the console width - 1, or 80 if that
+ *        cannot be determined. Note that long tokens in a help string
  *        can go past this.
  *      - helpCol {Number} Set to specify a specific column at which
  *        option help will be aligned. By default this is determined
@@ -591,7 +592,7 @@ Parser.prototype.help = function help(config) {
     assert.optionalBool(config.includeEnv, 'config.includeEnv');
     assert.optionalBool(config.includeDefault, 'config.includeDefault');
     assert.optionalBool(config.helpWrap, 'config.helpWrap');
-    var maxCol = config.maxCol || 80;
+    var maxCol = config.maxCol || ( process.stdout.columns ? process.stdout.columns - 1 : 80 );
     var minHelpCol = config.minHelpCol || 20;
     var maxHelpCol = config.maxHelpCol || 40;
 


### PR DESCRIPTION
This, to my eye at least, tends to produce nicer output, especially when the terminal is over or under-sized.