### PR TITLE
Fix completion log saving in current directory when program name contains certain characters

### DIFF
--- a/etc/dashdash.bash_completion.in
+++ b/etc/dashdash.bash_completion.in
@@ -71,10 +71,16 @@
 
 
 # Debugging this completion:
-#   1. Uncomment the "_{{name}}_log_file=..." line.
+#   1. Uncomment the "_log_file=..." line.
 #   2. 'tail -f /var/tmp/dashdash-completion.log' in one terminal.
 #   3. Re-source this bash completion file.
-#_{{name}}_log=/var/tmp/dashdash-completion.log
+
+function _{{name}}_completion_logfile {
+    local _log_file=/dev/null
+    #_log_file=/var/tmp/dashdash-completion.log
+    echo $_log_file
+}
+
 
 function _{{name}}_completer {
 
@@ -335,24 +341,20 @@ function _{{name}}_completer {
 # adapted from 'npm completion'.
 if type complete &>/dev/null; then
     function _{{name}}_completion {
-        local _log_file=/dev/null
-        [[ -z "$_{{name}}_log" ]] || _log_file="$_{{name}}_log"
         COMPREPLY=($(COMP_CWORD="$COMP_CWORD" \
             COMP_LINE="$COMP_LINE" \
             COMP_POINT="$COMP_POINT" \
             _{{name}}_completer -- "${COMP_WORDS[@]}" \
-            2>$_log_file)) || return $?
+            2>$(_{{name}}_completion_logfile))) || return $?
     }
     complete -o default -F _{{name}}_completion {{name}}
 elif type compdef &>/dev/null; then
     function _{{name}}_completion {
-        local _log_file=/dev/null
-        [[ -z "$_{{name}}_log" ]] || _log_file="$_{{name}}_log"
         compadd -- $(COMP_CWORD=$((CURRENT-1)) \
             COMP_LINE=$BUFFER \
             COMP_POINT=0 \
             _{{name}}_completer -- "${words[@]}" \
-            2>$_log_file)
+            2>$(_{{name}}_completion_logfile))
     }
     compdef _{{name}}_completion {{name}}
 elif type compctl &>/dev/null; then
@@ -363,13 +365,11 @@ elif type compctl &>/dev/null; then
         let cword-=1
         read -l line
         read -ln point
-        local _log_file=/dev/null
-        [[ -z "$_{{name}}_log" ]] || _log_file="$_{{name}}_log"
         reply=($(COMP_CWORD="$cword" \
             COMP_LINE="$line" \
             COMP_POINT="$point" \
             _{{name}}_completer -- "${words[@]}" \
-            2>$_log_file)) || return $?
+            2>$(_{{name}}_completion_logfile))) || return $?
     }
     compctl -K _{{name}}_completion {{name}}
 fi


### PR DESCRIPTION
### Circumstances triggering the bug
While generating bash completion with dashdash through [cmdln](https://github.com/trentm/node-cmdln), I noticed that debugging logs for the completion were being written to my current directory. My program is called `validana-cli`, and the minus sign in that name causes my issue. This will happen for any program with a minus sign in the name; which is not uncommon for command line programs.

### Analysis of the bug
Specifically, in dashdash debugging of completion is enabled by uncommenting a variable. This name of the variable contains the name of the program, I presume so that enabling completion debugging for a specific program won't cause many other programs using dashdash to start spewing out logfiles as well.

The problem is that if the program name contains a character that is not a valid character in a shell variable name (as in my case, the minus sign), the check the script uses will always succeed, and the filename it will use will be a combination of the last part of the program name and and a part of the broken variable name. Since this filename will also never contains any slashes, it will write this logfile to the current directory, spewing log files wherever the user goes and tries to use completion.

### Proposed resolution
This pull request resolves this by using a function instead of a variable to store the filename for the debug log. Since functions names in bash are allowed a larger set of characters, this resolves the problem. It does so for all possible characters dashdash supports (if the program name would contain a character which is also not valid in a function name, most of the completion script would break anyway).

### Impact of changes
Since this change is only touching the `bash_completion.in` template file this change should not have any impact outside of the completion functionality. Since the changed code is specifically for debugging purposes and should never be triggered during normal use, impact on consumers of this package should be negligible.

### Additional comments
@trentm If you decide to merge and publish this fix, could you also update your cmdln package to depend on the new version? That was users of that package (such as myself :) ) may also benefit from this fix.